### PR TITLE
Add About dialog for macOS

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -23,6 +23,9 @@
 #include <QStackedWidget>
 #include <QSplitter>
 #include <QHeaderView>
+#include <QMenuBar>
+#include <QMenu>
+#include <QAction>
 #include <QCloseEvent>
 
 namespace DiffLoupe {
@@ -33,6 +36,7 @@ MainWindow::MainWindow(QWidget *parent)
 {
     ui->setupUi(this);
     setupUi();
+    setupMenu();
     setupShortcuts();
 }
 
@@ -98,6 +102,16 @@ void MainWindow::setupUi()
     m_viewerStack->addWidget(new DiffLoupe::DiffViewer(this));
     m_viewerStack->addWidget(new DiffLoupe::ImageViewer(this));
     m_viewerStack->addWidget(new DiffLoupe::HexViewer(this));
+}
+
+void MainWindow::setupMenu()
+{
+    // "ヘルプ" メニューに "このソフトについて" を追加
+    QMenu *helpMenu = menuBar()->addMenu(tr("&Help"));
+    QAction *aboutAction = helpMenu->addAction(tr("このソフトについて..."));
+    aboutAction->setMenuRole(QAction::AboutRole);
+    connect(aboutAction, &QAction::triggered,
+            this, &MainWindow::showAboutDialog);
 }
 
 void MainWindow::showEvent(QShowEvent *event) {
@@ -435,6 +449,12 @@ void MainWindow::clearViewers() {
     static_cast<DiffViewer*>(m_viewerStack->widget(0))->clear();
     static_cast<ImageViewer*>(m_viewerStack->widget(1))->clear();
     static_cast<HexViewer*>(m_viewerStack->widget(2))->clear();
+}
+
+void MainWindow::showAboutDialog()
+{
+    QMessageBox::about(this, tr("このソフトについて"),
+                       tr("DiffLoupe\nフォルダ・ファイル比較ツール"));
 }
 
 } // namespace DiffLoupe

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -69,6 +69,9 @@ private slots:
     
     // 隠しファイル表示切り替え
     void onShowHiddenChanged(bool checked);
+
+    // "このソフトについて" ダイアログ表示
+    void showAboutDialog();
     
     // ワーカースレッドからの結果受信
     void onComparisonFinished(const std::vector<DiffResult> &results);
@@ -78,6 +81,7 @@ private:
     // UI初期化
     void setupUi();
     void setupShortcuts();
+    void setupMenu();
     
     // ツリー関連
     void populateTrees(const std::vector<DiffResult> &results);


### PR DESCRIPTION
## Summary
- create About dialog to show application info
- add menu under Help with macOS AboutRole

## Testing
- `cmake -S . -B build` *(fails: Qt5::DBus target not found)*

------
https://chatgpt.com/codex/tasks/task_e_687514672ee8832296523b49931058b4