### PR TITLE
Add modern UI toggle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,14 +10,14 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/forms)
 
 # Qt5とQt6の両方に対応
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core DBus)
 
 if (QT_VERSION_MAJOR EQUAL 6)
     # Vulkanヘッダーが無い環境でも警告のみで進むようにする
     set(CMAKE_DISABLE_FIND_PACKAGE_WrapVulkanHeaders ON)
-    find_package(Qt6 REQUIRED COMPONENTS Core Widgets Concurrent Core5Compat)
+    find_package(Qt6 REQUIRED COMPONENTS Core Widgets Concurrent Core5Compat DBus)
 else()
-    find_package(Qt5 REQUIRED COMPONENTS Core Widgets Concurrent)
+    find_package(Qt5 REQUIRED COMPONENTS Core Widgets Concurrent DBus)
 endif()
 
 # ソースファイル

--- a/Python/modern_theme.qss
+++ b/Python/modern_theme.qss
@@ -1,0 +1,20 @@
+/* Simple dark theme for modern mode */
+QWidget {
+    background-color: #2b2b2b;
+    color: #dddddd;
+}
+QPushButton, QComboBox, QRadioButton, QCheckBox {
+    background-color: #3c3f41;
+    border: 1px solid #555;
+    padding: 3px;
+}
+QTreeWidget, QPlainTextEdit {
+    background-color: #313335;
+}
+QMenuBar, QMenu {
+    background-color: #2b2b2b;
+}
+QProgressBar {
+    background-color: #313335;
+    color: #dddddd;
+}

--- a/Python/ui_main.py
+++ b/Python/ui_main.py
@@ -746,6 +746,7 @@ class MainWindow(QMainWindow):
         self.comparison_results = []  # 比較結果を保存
         self.current_filter = 0  # 現在のフィルターモード
         self.current_sort = 0  # 現在のソートモード
+        self.modern_mode = False  # モダンUIモード
         self.init_ui()
 
     def create_viewer_panel(self):
@@ -928,9 +929,19 @@ class MainWindow(QMainWindow):
         self.filter_group.buttonClicked.connect(self.on_filter_changed)
         self.filter_reset_btn.clicked.connect(self.reset_filter)
         self.sort_combo.currentIndexChanged.connect(self.on_sort_changed)
-        
+
+        # メニューを設定
+        self._setup_menu()
+
         # キーボードショートカットを設定
         self._setup_shortcuts()
+
+    def _setup_menu(self):
+        """メニューバーを設定"""
+        settings_menu = self.menuBar().addMenu("設定")
+        self.modern_action = settings_menu.addAction("モダンUIモード")
+        self.modern_action.setCheckable(True)
+        self.modern_action.toggled.connect(self.toggle_modern_mode)
     
     def _setup_shortcuts(self):
         """キーボードショートカットを設定"""
@@ -1378,3 +1389,16 @@ class MainWindow(QMainWindow):
             color = QColor("#dddddd")
             item.setForeground(0, QBrush(QColor("gray")))
         item.setBackground(0, QBrush(color))
+
+    def toggle_modern_mode(self, checked):
+        """モダンUIモードの切り替え"""
+        self.modern_mode = checked
+        if checked:
+            qss_path = os.path.join(os.path.dirname(__file__), "modern_theme.qss")
+            try:
+                with open(qss_path, "r", encoding="utf-8") as f:
+                    self.setStyleSheet(f.read())
+            except OSError:
+                self.setStyleSheet("")
+        else:
+            self.setStyleSheet("")

--- a/resources/modern_theme.qss
+++ b/resources/modern_theme.qss
@@ -1,0 +1,20 @@
+/* Simple dark theme for modern mode */
+QWidget {
+    background-color: #2b2b2b;
+    color: #dddddd;
+}
+QPushButton, QComboBox, QRadioButton, QCheckBox {
+    background-color: #3c3f41;
+    border: 1px solid #555;
+    padding: 3px;
+}
+QTreeWidget, QPlainTextEdit {
+    background-color: #313335;
+}
+QMenuBar, QMenu {
+    background-color: #2b2b2b;
+}
+QProgressBar {
+    background-color: #313335;
+    color: #dddddd;
+}

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -2,6 +2,7 @@
 <RCC version="1.0">
     <qresource prefix="/">
         <file>icons/icon.png</file>
+        <file>modern_theme.qss</file>
 
         <!-- 翻訳ファイル（将来追加） -->
         <!-- <file>i18n/DiffLoupe_ja.qm</file> -->

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -24,6 +24,10 @@
 #include <QSplitter>
 #include <QHeaderView>
 #include <QCloseEvent>
+#include <QMenuBar>
+#include <QMenu>
+#include <QAction>
+#include <QFile>
 
 namespace DiffLoupe {
 
@@ -33,6 +37,7 @@ MainWindow::MainWindow(QWidget *parent)
 {
     ui->setupUi(this);
     setupUi();
+    setupMenu();
     setupShortcuts();
 }
 
@@ -104,6 +109,15 @@ void MainWindow::showEvent(QShowEvent *event) {
     QMainWindow::showEvent(event);
     // スプリッターのサイズ設定
     ui->mainSplitter->setSizes({250, 900, 250});
+}
+
+void MainWindow::setupMenu()
+{
+    QMenu *settingsMenu = menuBar()->addMenu(tr("設定"));
+    m_modernAction = settingsMenu->addAction(tr("モダンUIモード"));
+    m_modernAction->setCheckable(true);
+    connect(m_modernAction, &QAction::toggled,
+            this, &MainWindow::toggleModernMode);
 }
 
 void MainWindow::setupShortcuts()
@@ -435,6 +449,22 @@ void MainWindow::clearViewers() {
     static_cast<DiffViewer*>(m_viewerStack->widget(0))->clear();
     static_cast<ImageViewer*>(m_viewerStack->widget(1))->clear();
     static_cast<HexViewer*>(m_viewerStack->widget(2))->clear();
+}
+
+void MainWindow::toggleModernMode(bool enabled)
+{
+    m_modernMode = enabled;
+    if (enabled) {
+        QFile f(":/modern_theme.qss");
+        if (f.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            setStyleSheet(QString::fromUtf8(f.readAll()));
+            f.close();
+        } else {
+            setStyleSheet("");
+        }
+    } else {
+        setStyleSheet("");
+    }
 }
 
 } // namespace DiffLoupe

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -21,6 +21,8 @@ class QRadioButton;
 class QButtonGroup;
 class QStackedWidget;
 class QSplitter;
+class QMenu;
+class QAction;
 QT_END_NAMESPACE
 
 namespace DiffLoupe {
@@ -78,6 +80,7 @@ private:
     // UI初期化
     void setupUi();
     void setupShortcuts();
+    void setupMenu();
     
     // ツリー関連
     void populateTrees(const std::vector<DiffResult> &results);
@@ -98,6 +101,7 @@ private:
     
     // ワーカースレッド管理
     void cleanupWorkers();
+    void toggleModernMode(bool enabled);
     
 private:
     std::unique_ptr<Ui::MainWindow> ui;
@@ -135,6 +139,10 @@ private:
     
     // その他の設定
     QCheckBox *m_showHiddenCheckbox;
+
+    // メニュー
+    QAction *m_modernAction = nullptr;
+    bool m_modernMode = false;
     
     // ビューアスタック
     QStackedWidget *m_viewerStack;


### PR DESCRIPTION
## Summary
- include Qt DBus in build
- add dark theme stylesheet in resources
- add menu option in C++ UI for toggling modern mode

## Testing
- `cmake -B build && cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_687514243b0c8322aa982151619aa106