### PR TITLE
Add SwiftUI macOS skeleton

### DIFF
--- a/SwiftUI/.gitignore
+++ b/SwiftUI/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/SwiftUI/Package.swift
+++ b/SwiftUI/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "DiffLoupeSwiftUI",
+    platforms: [
+        .macOS(.v12)
+    ],
+    products: [
+        .executable(name: "DiffLoupeSwiftUI", targets: ["DiffLoupeSwiftUI"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "DiffLoupeSwiftUI",
+            path: "Sources"
+        )
+    ]
+)

--- a/SwiftUI/README.md
+++ b/SwiftUI/README.md
@@ -1,0 +1,14 @@
+# DiffLoupe MacOS SwiftUI
+
+This folder contains a minimal SwiftUI version of **DiffLoupe** for macOS.
+The project is provided as a Swift Package that can be opened with Xcode.
+
+## Build
+
+On macOS with Xcode 15 or later:
+
+1. Open the `Package.swift` in Xcode.
+2. Build and run the `DiffLoupeSwiftUI` target.
+
+This is only a basic skeleton demonstrating how a native SwiftUI version
+could be started. Features from the C++/Qt and Python versions are not yet implemented.

--- a/SwiftUI/Sources/ContentView.swift
+++ b/SwiftUI/Sources/ContentView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("DiffLoupe for macOS (SwiftUI)")
+            .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/SwiftUI/Sources/DiffLoupeSwiftUIApp.swift
+++ b/SwiftUI/Sources/DiffLoupeSwiftUIApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct DiffLoupeSwiftUIApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SwiftUI folder with macOS SwiftUI skeleton
- include minimal Package.swift, ContentView, and App entry point
- document build steps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876793389e4832285df2ee6a183cec9