### PR TITLE
Remove binary translation file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+resources/translations/*.qm

--- a/README.md
+++ b/README.md
@@ -83,8 +83,16 @@ DiffLoupe-Qt/
 ├── resources/            # リソース
 │   ├── resources.qrc     # リソースファイル
 │   ├── icons/           # アイコン
-│   └── translations/    # 翻訳ファイル
+│   └── translations/    # 翻訳ファイル (.ts を配置)
 └── tests/               # テスト
+```
+
+翻訳ファイル (.qm) が存在しない場合、アプリ起動時に `lrelease` コマンドで
+自動生成されます。手動で生成する場合は次のコマンドを実行します:
+
+```bash
+lrelease resources/translations/DiffLoupe_en_US.ts \
+    -qm resources/translations/DiffLoupe_en_US.qm
 ```
 
 ## 実装状況

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -4,7 +4,6 @@
         <file>icons/icon.png</file>
         <file>modern_theme.qss</file>
 
-        <!-- 翻訳ファイル（将来追加） -->
-        <!-- <file>i18n/DiffLoupe_ja.qm</file> -->
+        <!-- 翻訳ファイルはtranslations/に配置 -->
     </qresource>
 </RCC>

--- a/resources/translations/DiffLoupe_en_US.ts
+++ b/resources/translations/DiffLoupe_en_US.ts
@@ -1,0 +1,195 @@
+<?xml version='1.0' encoding='utf-8'?>
+<TS version="2.1" language="en_US">
+<context>
+    <name>DiffLoupe::MainWindow</name>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="14" />
+        <source>ディフルーペ - フォルダ差分表示</source>
+        <translation>DiffLoupe - Folder Diff Viewer</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="30" />
+        <source>フォルダAを選択</source>
+        <translation>Select Folder A</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="37" />
+        <source>フォルダA: (未選択)</source>
+        <translation>Folder A: (not selected)</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="51" />
+        <source>フォルダBを選択</source>
+        <translation>Select Folder B</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="58" />
+        <source>フォルダB: (未選択)</source>
+        <translation>Folder B: (not selected)</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="72" />
+        <source>比較 (F5)</source>
+        <translation>Compare (F5)</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="88" />
+        <source>表示モード:</source>
+        <translation>View mode:</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="95" />
+        <source>テキスト</source>
+        <translation>Text</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="114" />
+        <source>画像</source>
+        <translation>Image</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="130" />
+        <source>バイナリ</source>
+        <translation>Binary</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="146" />
+        <location filename="../../forms/mainwindow.ui" line="175" />
+        <location filename="../../forms/mainwindow.ui" line="199" />
+        <location filename="../../forms/mainwindow.ui" line="293" />
+        <location filename="../../forms/mainwindow.ui" line="316" />
+        <location filename="../../forms/mainwindow.ui" line="342" />
+        <source>|</source>
+        <translation>|</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="153" />
+        <source>行単位</source>
+        <translation>Line-based</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="162" />
+        <source>差分比較モード: 行単位/文字単位を切り替え</source>
+        <translation>Diff mode: toggle line/char</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="182" />
+        <source>エンコーディング:</source>
+        <translation>Encoding:</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="206" />
+        <source>隠しファイル</source>
+        <translation>Hidden files</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="209" />
+        <source>ドットで始まるファイル・フォルダを表示します</source>
+        <translation>Show dot files and folders</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="235" />
+        <source>フィルター:</source>
+        <translation>Filter:</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="242" />
+        <source>すべて</source>
+        <translation>All</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="248" />
+        <source>すべてのファイルを表示 (Ctrl+1)</source>
+        <translation>Show all files (Ctrl+1)</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="261" />
+        <source>欠落・新規</source>
+        <translation>Missing/New</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="264" />
+        <source>欠落しているファイルや新規ファイルのみ表示 (Ctrl+2)</source>
+        <translation>Show only missing or new files (Ctrl+2)</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="277" />
+        <source>差分のみ</source>
+        <translation>Different only</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="280" />
+        <source>内容に差分があるファイルのみ表示 (Ctrl+3)</source>
+        <translation>Show only files with differences (Ctrl+3)</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="300" />
+        <source>リセット</source>
+        <translation>Reset</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="303" />
+        <source>フィルターをリセットしてすべて表示 (Ctrl+R)</source>
+        <translation>Reset filter and show all (Ctrl+R)</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="323" />
+        <source>ファイル数: 0</source>
+        <translation>Files: 0</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="349" />
+        <source>ソート:</source>
+        <translation>Sort:</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="356" />
+        <source>ファイルの並び順を選択</source>
+        <translation>Choose file order</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="394" />
+        <location filename="../../forms/mainwindow.ui" line="407" />
+        <source>ファイル</source>
+        <translation>File</translation>
+    </message>
+    <message>
+        <location filename="../../forms/mainwindow.ui" line="399" />
+        <location filename="../../forms/mainwindow.ui" line="412" />
+        <source>状態</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="168" />
+        <source>&amp;Help</source>
+        <translation>&amp;Help</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="169" />
+        <source>このソフトについて...</source>
+        <translation>About this software...</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="175" />
+        <source>設定</source>
+        <translation>Settings</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="176" />
+        <source>モダンUIモード</source>
+        <translation>Modern UI mode</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="654" />
+        <source>このソフトについて</source>
+        <translation>About this software</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="655" />
+        <source>DiffLoupe
+フォルダ・ファイル比較ツール</source>
+        <translation>DiffLoupe
+Folder and File Comparison Tool</translation>
+    </message>
+</context>
+</TS>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,9 @@
 #include <QStyleFactory>
 #include <QLoggingCategory>
 #include <QDebug>
+#include <QFileInfo>
+#include <QProcess>
+#include <QStandardPaths>
 #include "mainwindow.h"
 
 // ログカテゴリの定義
@@ -59,10 +62,26 @@ int main(int argc, char *argv[])
 
     // 翻訳ファイルの読み込み（日本語対応）
     QTranslator translator;
+    const QString translationsDir = QCoreApplication::applicationDirPath()
+                                    + "/translations";
     const QStringList uiLanguages = QLocale::system().uiLanguages();
     for (const QString &locale : uiLanguages) {
         const QString baseName = "DiffLoupe_" + QLocale(locale).name();
-        if (translator.load(":/i18n/" + baseName)) {
+        const QString qmPath = translationsDir + "/" + baseName + ".qm";
+        const QString tsPath = translationsDir + "/" + baseName + ".ts";
+
+        bool loaded = translator.load(":/i18n/" + baseName);
+        if (!loaded && QFileInfo::exists(qmPath)) {
+            loaded = translator.load(qmPath);
+        }
+        if (!loaded && QFileInfo::exists(tsPath)) {
+            const QString lrelease = QStandardPaths::findExecutable("lrelease");
+            if (!lrelease.isEmpty()) {
+                QProcess::execute(lrelease, {tsPath, "-qm", qmPath});
+                loaded = translator.load(qmPath);
+            }
+        }
+        if (loaded) {
             app.installTranslator(&translator);
             break;
         }


### PR DESCRIPTION
## Summary
- remove DiffLoupe_en_US.qm from repository
- load translations from external directory when available
- document how to generate .qm file
- ignore compiled translation files
- generate `.qm` files automatically at startup when missing

## Testing
- `cmake -B build && cmake --build build -j4`


------
https://chatgpt.com/codex/tasks/task_e_687c4bfe11b0832298dbed029ebaeada