### PR TITLE
Ignore DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 build/
 resources/translations/*.qm
+
+# Ignore macOS Finder metadata
+.DS_Store


### PR DESCRIPTION
## Summary
- avoid tracking macOS Finder metadata by adding `.DS_Store` to `.gitignore`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e1ed3c4588322af4c0deda9c7716b